### PR TITLE
Implement modular LangGraph MVP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Contributor Guidelines
+
+This repository demonstrates a light-weight LangGraph workflow for building
+learning modules. Changes should follow these conventions:
+
+- Keep the workflow modular. Each LangGraph node should be a small function that
+  accepts and returns a dictionary of state.
+- Add a descriptive comment block at the top of every Python file explaining its
+  purpose and overall structure.
+- Prefer simple, easily testable functions. If logic grows, factor it into
+  helpers under `src/lmb_agent`.
+- Run `ruff --fix` and `pytest` before committing when tests exist.
+- Document new commands or examples in `README.md`.

--- a/README.md
+++ b/README.md
@@ -1,143 +1,36 @@
-# 📓 `nb‑module‑agent`
-_A turnkey Python package that lets an LLM **plan, generate and quality‑check complete Jupyter‑notebook learning modules** (e.g. “Build me a short _NumPy_ tutorial”).  
-It blends **LangChain/LangGraph internal tools** with **Model Context Protocol (MCP) tools** for secure, best‑practice extensibility._
+# Learning Module Builder Agent
 
----
+This project demonstrates a minimal LangGraph workflow for building
+Jupyter-based learning modules. The agent clarifies the topic,
+plans a short outline, then generates notebook cells.
 
-## ✨ Key Features
-| Capability | Implementation |
-|------------|----------------|
-|**Clarification & planning**|LangGraph state machine in `agent.py` asks follow‑up questions, then produces an outline.|
-|**Code execution & validation**|`PythonREPLTool` runs snippets to be sure they work :contentReference[oaicite:0]{index=0}|
-|**External integrations (GitHub, Drive, etc.)**|Done via MCP tools exposed on one or more MCP servers using **`langchain‑mcp‑adapters`** :contentReference[oaicite:1]{index=1}|
-|**Notebook assembly**|`nbformat` compiles markdown + code cells into a `.ipynb`.|
-|**Self‑critique**|A second LLM pass flags missing concepts, bad code, or unsafe content.|
-|**Dev‑container**|Reproducible VS Code setup with Docker, Poetry, pre‑commit, Jupyter port‑forward.|
-|**CI/CD**|GitHub Actions runs unit tests, lint, mypy and sample‑notebook smoke tests.|
+## Features
 
----
+- Modular nodes in `src/lmb_agent/nodes.py`.
+- Agent assembly in `src/lmb_agent/agent.py`.
+- Command line interface via `python -m lmb_agent`.
 
-## 🔧 Quick‑start
+## Quick start
 
 ```bash
-git clone https://github.com/your‑org/nb‑module‑agent
-cd nb‑module‑agent
-devcontainer open .          # or: docker compose up dev
-poetry install --with dev
-python -m nb_module_agent.cli \
-   "Create a short **Pandas** beginner module"
-Minimal code example
-python
-Copy
-from langchain.chat_models import ChatOpenAI
-from langchain.tools.python import PythonREPLTool           # internal Lang tool
-from langchain_mcp_adapters.client import (
-    MultiServerMCPClient, mcp_tools_from_schema)            # MCP tool bridge
-from langgraph.prebuilt import create_react_agent
+pip install -e .
+python -m lmb_agent "Intro to NumPy"
+```
 
-# 1. Discover external MCP tools (e.g. GitHub, Google Drive)
-mcp = MultiServerMCPClient(["https://mcp.my‑org.ai"])
-mcp_tools = mcp_tools_from_schema(mcp)
+## Repository layout
 
-# 2. Build an agent with BOTH internal and MCP tools
-tools = [PythonREPLTool()] + mcp_tools
-agent = create_react_agent(
-    llm=ChatOpenAI(model="gpt‑4o‑mini"),
-    tools=tools,
-    system_prompt="You are a rigorous notebook‑module creator."
-)
+```
+learning-module-builder-agent/
+├── src/lmb_agent/
+│   ├── __init__.py
+│   ├── __main__.py      # ``python -m lmb_agent`` entry point
+│   ├── agent.py         # LangGraph workflow
+│   ├── cli.py           # Command line interface
+│   └── nodes/           # Reusable workflow steps
+├── tests/               # Basic unit tests
+├── pyproject.toml       # Package metadata
+└── README.md
+```
 
-# 3. Invoke
-agent.invoke("Build a short *Matplotlib* tutorial notebook for beginners.")
-🗂️ Repository Layout
-bash
-Copy
-nb-module-agent/
-├─ .devcontainer/               # VS Code Dev Container
-│  ├─ devcontainer.json         # ports, extensions, postCreate
-│  └─ Dockerfile                # Python 3.12‑slim + Jupyter + Poetry
-├─ .github/
-│  └─ workflows/ci.yml          # lint, type‑check, tests
-├─ src/nb_module_agent/
-│  ├─ __init__.py               # version, public API
-│  ├─ agent.py                  # LangGraph state graph (clarify → plan → gen)
-│  ├─ planning.py               # Lesson‑plan templates & validators
-│  ├─ notebook_builder.py       # nbformat helpers
-│  ├─ tools/
-│  │  ├─ repl.py                # Thin wrapper around PythonREPLTool
-│  │  └─ mcp_client.py          # Utility to fetch & cache MCP tool schemas
-│  └─ cli.py                    # `python -m nb_module_agent` entry‑point
-├─ tests/
-│  ├─ test_planner.py
-│  └─ test_notebook_compile.py
-├─ notebooks/                   # Sample outputs (smoke‑tested in CI)
-├─ pyproject.toml               # Poetry, type‑stub, Ruff, mypy config
-├─ README.md                    # ← you are here
-└─ LICENSE
-File/Dir highlights
-Path	Why it exists
-agent.py	Defines a LangGraph StateGraph: Clarify → Plan → Critique → GenerateCells → CompileNotebook
-tools/mcp_client.py	One‑liner to wrap any MCP server and expose its tools to the agent.
-notebook_builder.py	Transforms validated JSON sections into real notebook cells (nbformat.v4).
-tests/	Unit tests must pass ruff + mypy + pytest to merge.
-
-🖥️ Dev‑container
-.devcontainer/devcontainer.json
-
-jsonc
-Copy
-{
-  "name": "nb-module-agent",
-  "image": "mcr.microsoft.com/devcontainers/python:3.12",
-  "features": { "ghcr.io/devcontainers/features/docker-in-docker:2": {} },
-  "postCreateCommand": "poetry install --with dev && pre-commit install",
-  "forwardPorts": [8888],
-  "customizations": {
-    "vscode": {
-      "extensions": [
-        "ms-python.python",
-        "ms-python.vscode-pylance",
-        "ms-azuretools.vscode-docker"
-      ]
-    }
-  }
-}
-.devcontainer/Dockerfile
-
-Dockerfile
-Copy
-FROM mcr.microsoft.com/devcontainers/python:3.12
-
-# System deps
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
-
-# Poetry already baked in; just ensure nbformat + jupyter for local tests
-RUN pip install --no-cache-dir "nbformat>=5.10" jupyter
-📜 Best‑practice checklist
-Domain	What we do	References
-Packaging	PEP 621 / pyproject.toml; no setup.py	
-Code‑style	Ruff (ruff check --fix) + Black profile	
-Types	mypy strict mode; CI fails on Any leakage	
-Security	Pinned deps via Poetry lock; automated pip‑audit on PRs	
-LLM Ops	Separate system/assistant prompts, deterministic IDs for each graph node; retries + timeouts with lc_retry decorator	
-External tools	Use MCP adapters to avoid embedding secrets; tool schemas fetched dynamically 
-changelog.langchain.com
-Notebook hygiene	All generated notebooks include a pre‑executed kernel UUID & metadata for reproducible CI smoke runs	
-
-🚀 Roadmap
-🔍 Add Tavily search tool for “research‑first” lessons
-
-🧪 Integrate pytest‑nb to execute notebooks in CI
-
-🌐 Optional web UI (FastAPI + Mermaid flow viz)
-
-📄 License
-MIT — see LICENSE.
-
-The Model Context Protocol (MCP) is an open standard announced by Anthropic for safe, tool‑augmented LLM workflows 
-theverge.com
-.
-
-makefile
-Copy
-::contentReference[oaicite:4]{index=4}
+The example is intentionally lightweight so you can extend the workflow
+with your own LangGraph nodes or tooling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "learning-module-builder-agent"
+version = "0.1.0"
+description = "Minimal LangGraph workflow for building Jupyter-based learning modules"
+authors = [{name = "Example", email = "example@example.com"}]
+readme = "README.md"
+requires-python = ">=3.10"
+
+[project.scripts]
+lmb-agent = "lmb_agent.cli:main"
+
+[project.dependencies]
+langchain = "*"
+langgraph = "*"
+openai = "*"

--- a/src/lmb_agent/__init__.py
+++ b/src/lmb_agent/__init__.py
@@ -1,0 +1,10 @@
+"""Top-level package for Learning Module Builder Agent.
+
+This package exposes simple entry-points for building Jupyter-based
+learning modules via a LangGraph agentic workflow.
+"""
+
+__all__ = ["build_agent", "clarify", "plan", "generate"]
+
+from .agent import build_agent
+from .nodes import clarify, generate, plan

--- a/src/lmb_agent/__main__.py
+++ b/src/lmb_agent/__main__.py
@@ -1,0 +1,9 @@
+"""Module execution entry point.
+
+Running ``python -m lmb_agent`` is equivalent to invoking the
+``lmb_agent.cli`` module.
+"""
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/lmb_agent/agent.py
+++ b/src/lmb_agent/agent.py
@@ -1,0 +1,28 @@
+"""Build and run the LangGraph-powered learning module agent.
+
+This module assembles the reusable node functions into a LangGraph
+`StateGraph`. The resulting graph clarifies the desired topic,
+plans a short lesson outline, then generates notebook cells.
+"""
+from __future__ import annotations
+
+from langchain.chat_models import ChatOpenAI
+from langgraph.graph import START, END, StateGraph
+
+from .nodes import clarify, generate, plan
+
+
+def build_agent(llm: ChatOpenAI | None = None) -> StateGraph:
+    """Return a minimal agent graph."""
+    llm = llm or ChatOpenAI(model="gpt-4o")
+    graph = StateGraph(dict)
+
+    graph.add_node("clarify", lambda state: clarify(state, llm))
+    graph.add_node("plan", lambda state: plan(state, llm))
+    graph.add_node("generate", lambda state: generate(state, llm))
+
+    graph.add_edge(START, "clarify")
+    graph.add_edge("clarify", "plan")
+    graph.add_edge("plan", "generate")
+    graph.add_edge("generate", END)
+    return graph.compile()

--- a/src/lmb_agent/cli.py
+++ b/src/lmb_agent/cli.py
@@ -1,0 +1,24 @@
+"""Command-line interface for the Learning Module Builder Agent.
+
+Invoke this module with a lesson topic to run the LangGraph agent
+and print the generated notebook cells.
+"""
+from __future__ import annotations
+
+import argparse
+
+from .agent import build_agent
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the learning module agent")
+    parser.add_argument("topic", help="Short lesson topic")
+    args = parser.parse_args()
+
+    agent = build_agent()
+    result = agent.invoke({"topic": args.topic})
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lmb_agent/nodes/__init__.py
+++ b/src/lmb_agent/nodes/__init__.py
@@ -1,0 +1,32 @@
+"""Reusable LangGraph nodes.
+
+This module contains simple functions implementing each step
+of the learning module workflow so they can be composed into
+LangGraph graphs.
+"""
+from __future__ import annotations
+
+from typing import Dict
+
+from langchain.chat_models import ChatOpenAI
+
+
+def clarify(state: Dict, llm: ChatOpenAI) -> Dict:
+    """Ask the user for a concise topic clarification."""
+    question = "Please provide a short topic for the learning module"
+    state["topic"] = llm.predict(question)
+    return state
+
+
+def plan(state: Dict, llm: ChatOpenAI) -> Dict:
+    """Create a brief lesson outline for the clarified topic."""
+    prompt = f"Create an outline for a lesson on {state['topic']}"
+    state["outline"] = llm.predict(prompt)
+    return state
+
+
+def generate(state: Dict, llm: ChatOpenAI) -> Dict:
+    """Generate notebook cells for the given outline."""
+    prompt = f"Generate notebook cells for: {state['outline']}"
+    state["cells"] = llm.predict(prompt)
+    return state

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,19 @@
+"""Basic tests for the MVP agent."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from lmb_agent import build_agent  # noqa: E402
+
+
+class DummyLLM:
+    def predict(self, prompt: str) -> str:  # noqa: D401
+        """Return a placeholder response."""
+        return "dummy"
+
+
+def test_build_agent():
+    graph = build_agent(llm=DummyLLM())
+    result = graph.invoke({"topic": "Test"})
+    assert "cells" in result


### PR DESCRIPTION
## Summary
- add `pyproject.toml` package metadata
- split workflow steps into `nodes` module
- build agent graph from reusable nodes
- expose CLI and `__main__` entry points
- document project structure and provide basic tests

## Testing
- `ruff check --fix .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b80f22d388327acda99ba2b1ba603